### PR TITLE
Add top match search parameter

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -565,6 +565,7 @@ type Response struct {
 	Query             Person        `json:"query"`
 	SearchID          string        `json:"@search_id"`
 	Sources           []Source      `json:"sources"`
+	TopMatch          bool          `json:"top_match"`
 	VisibleSources    int           `json:"@visible_sources"`
 	Warnings          []string      `json:"warnings"`
 }

--- a/pipl.go
+++ b/pipl.go
@@ -65,6 +65,9 @@ type SearchParameters struct {
 
 	// LiveFeeds specifies whether to use live data sources
 	LiveFeeds bool
+
+	// Returns the best high ranking match to your search. API will return either a Person (when high scoring profile is found) or a No Match
+	TopMatch bool
 }
 
 // ThumbnailSettings is for the thumbnail url settings to be automatically returned
@@ -114,6 +117,7 @@ func NewClient(apiKey string, clientOptions *Options) (c *Client, err error) {
 	c.Parameters.Search.apiKey = apiKey
 	c.Parameters.Search.HideSponsored = true
 	c.Parameters.Search.InferPersons = false
+	c.Parameters.Search.TopMatch = false
 	c.Parameters.Search.LiveFeeds = true
 	c.Parameters.Search.MatchRequirements = MatchRequirementsNone
 	c.Parameters.Search.MinimumMatch = MinimumMatch
@@ -219,6 +223,11 @@ func (c *Client) Search(searchPerson *Person) (response *Response, err error) {
 	// Add source category requirements?
 	if c.Parameters.Search.SourceCategoryRequirements != SourceCategoryRequirementsNone {
 		postData.Add("source_category_requirements", string(c.Parameters.Search.SourceCategoryRequirements))
+	}
+
+	// Ask for the top match?
+	if c.Parameters.Search.TopMatch {
+		postData.Add("top_match", "true")
 	}
 
 	// Parse the search object


### PR DESCRIPTION
Hello! Thank you for your project!

Some use cases of pipl API require exactly one most probable search result and API has [`top_match`](https://docs.pipl.com/docs/top_match-configuration-parameter) search parameter exactly for this case. It's quite useful and saves request to server because we can filter most probable result on API side.

Please take a look at this PR, this change is vital for me and I hope it'll be useful for many others.