### PR TITLE
Use int64 for phone number

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -131,7 +131,7 @@ type Phone struct {
 	ValidSince           string `json:"@valid_since,omitempty"`
 	CountryCode          int    `json:"country_code,omitempty"`
 	Extension            int    `json:"extension,omitempty"`
-	Number               int    `json:"number,omitempty"`
+	Number               int64  `json:"number,omitempty"`
 	Current              bool   `json:"@current,omitempty"`
 	Inferred             bool   `json:"@inferred,omitempty"`
 }

--- a/helpers.go
+++ b/helpers.go
@@ -181,7 +181,7 @@ func (p *Person) AddURL(url string) (err error) {
 //
 // Plan: Landline phones are available in all plans, mobile phones
 // 		 in the BUSINESS plan only.
-func (p *Person) AddPhone(phoneNumber, countryCode int) (err error) {
+func (p *Person) AddPhone(phoneNumber int64, countryCode int) (err error) {
 
 	// Phone is required (min length unknown)
 	if phoneNumber == 0 {


### PR DESCRIPTION
Size of `int` type in Go is platform dependent. On 64bit platforms it's equal to int64 and on 32bit platforms it's equal to int32.

Nine-digit long phone numbers require int64 for proper representation. This PR fixes actual phone number size on 32bit platforms enforcing 64bit field size for phone numbers.