### PR TITLE
[Sync] Update project files from source repository (aa5dc77)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,8 @@ vendor/
 # Binaries for programs and plugins
 dist/
 !dist/linux/
+!dist/linux-amd64/
+!dist/linux-arm64/
 gin-bin
 *.exe
 *.exe~

--- a/.github/env/10-mage-x.env
+++ b/.github/env/10-mage-x.env
@@ -36,7 +36,7 @@
 # ================================================================================================
 
 # MAGE-X version
-MAGE_X_VERSION=v1.20.16
+MAGE_X_VERSION=v1.21.0
 
 # For mage-x development, set to 'true' to use local version instead of downloading from releases
 MAGE_X_USE_LOCAL=false
@@ -71,7 +71,7 @@ MAGE_X_NANCY_VERSION=v1.2.0
 MAGE_X_STATICCHECK_VERSION=2026.1
 MAGE_X_SWAG_VERSION=v1.16.6
 MAGE_X_YAMLFMT_VERSION=v0.21.0
-MAGE_X_BENCHSTAT_VERSION=v0.0.0-20260409210113-8e83ce0f7b1c
+MAGE_X_BENCHSTAT_VERSION=v0.0.0-20260512194132-3cf34090a3db
 MAGE_X_MAGE_VERSION=v1.17.2
 
 # ================================================================================================

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/autobuild@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
       #    uses a compiled language
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -76,6 +76,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable the upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## What Changed

* Updated `.dockerignore` to include `!dist/linux-amd64/` and `!dist/linux-arm64/` as additional exceptions to the `dist/` ignore rule
* Updated `MAGE_X_VERSION` from `v1.20.16` to `v1.21.0` in `.github/env/10-mage-x.env`
* Updated `MAGE_X_BENCHSTAT_VERSION` from `v0.0.0-20260409210113-8e83ce0f7b1c` to `v0.0.0-20260512194132-3cf34090a3db` in `.github/env/10-mage-x.env`
* Updated `github/codeql-action` references from commit `68bde559dea0fdcac2102bfdf6230c5f70eb485e` (v4.35.4) to `9e0d7b8d25671d64c341c19c0152d693099fb5ba` (v4.35.5) across three actions in `codeql-analysis.yml` (init, autobuild, analyze)
* Updated `github/codeql-action/upload-sarif` from commit `68bde559dea0fdcac2102bfdf6230c5f70eb485e` (v4.35.4) to `9e0d7b8d25671d64c341c19c0152d693099fb5ba` (v4.35.5) in `scorecard.yml`

## Why It Was Necessary

* Docker builds need to include architecture-specific Linux binaries (`linux-amd64` and `linux-arm64`) to support multi-platform container images
* Upgrading mage-x tooling to the latest version ensures access to bug fixes, improvements, and updated benchstat functionality
* CodeQL action updates provide the latest security scanning capabilities and maintain compatibility with GitHub's security features

## Testing Performed

* Verify Docker builds successfully include the newly whitelisted `dist/linux-amd64/` and `dist/linux-arm64/` directories
* Confirm CI workflows execute successfully with the updated mage-x v1.21.0 and benchstat versions
* Validate CodeQL analysis and scorecard workflows complete without errors using the updated v4.35.5 actions

## Impact / Risk

* **Low Risk**: Docker ignore changes only affect which distribution files are included in container builds, providing better multi-architecture support
* **Low Risk**: Mage-x and benchstat version bumps are minor updates within the tooling ecosystem and don't affect runtime behavior
* **Low Risk**: CodeQL patch version update (v4.35.4 → v4.35.5) is a minor security scanning tool upgrade with no breaking changes expected

<!-- go-broadcast-metadata
group:
  id: third-party-sdks
  name: third-party-sdks
diff_info:
  staged_repo_available: true
  changed_files_count: 4
  files_with_original_content: 4
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: aa5dc772d4c317a019b553f6129ffc6fbe7b7f82
  target_repo: mrz1836/go-pipl
  sync_commit: 7df18b53ca085e7d182ca3590a1c8c9019c8d76f
  sync_time: 2026-05-17T18:48:50-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 704
  - src: .github/actions
    dest: .github/actions
    files_synced: 0
    files_examined: 18
    files_excluded: 0
    processing_time_ms: 1493
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 706
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 1
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 773
  - src: .github/scripts
    dest: .github/scripts
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 797
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1841
  - src: .github/workflows
    dest: .github/workflows
    files_synced: 2
    files_examined: 26
    files_excluded: 0
    processing_time_ms: 1160
  - src: .vscode
    dest: .vscode
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 309
performance:
  total_files: 101
-->
